### PR TITLE
prime_db_schema.get_publication_infos return dictionary with tuple key

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -50,7 +50,7 @@ LAYMAN_CLIENT_URL=http://layman_client:3000/client/
 
 # client
 LAYMAN_CLIENT_PUBLIC_URL=http://localhost/client/
-LAYMAN_CLIENT_VERSION=fa393bbaabfc02cb9f4a931c5bf65154bb4b8fa8
+LAYMAN_CLIENT_VERSION=v1.3.0
 
 # extra hosts to be added to /etc/hosts
 EXTRA_HOST1=1.2.3.4:1.2.3.4

--- a/.env.dev
+++ b/.env.dev
@@ -52,7 +52,7 @@ LAYMAN_CLIENT_URL=http://layman_client:3000/client/
 
 # client
 LAYMAN_CLIENT_PUBLIC_URL=http://localhost:3000/client/
-LAYMAN_CLIENT_VERSION=fa393bbaabfc02cb9f4a931c5bf65154bb4b8fa8
+LAYMAN_CLIENT_VERSION=v1.3.0
 
 
 ##############################################################################

--- a/.env.test
+++ b/.env.test
@@ -52,7 +52,7 @@ LAYMAN_CLIENT_URL=http://layman_client_test:3000/client/
 
 # client
 LAYMAN_CLIENT_PUBLIC_URL=http://layman_test_run_1:8000/client/
-LAYMAN_CLIENT_VERSION=fa393bbaabfc02cb9f4a931c5bf65154bb4b8fa8
+LAYMAN_CLIENT_VERSION=v1.3.0
 
 
 ##############################################################################

--- a/src/layman/__init__.py
+++ b/src/layman/__init__.py
@@ -67,8 +67,8 @@ if settings.LAYMAN_REDIS.get(LAYMAN_DEPS_ADJUSTED_KEY) != 'done':
             import layman.common.prime_db_schema.schema_initialization as prime_db_schema
             prime_db_schema.check_schema_name(settings.LAYMAN_PRIME_SCHEMA)
             prime_db_schema.ensure_schema(settings.LAYMAN_PRIME_SCHEMA,
-                                          app,
-                                          settings.PUBLICATION_MODULES)
+                                          settings.PUBLICATION_MODULES,
+                                          settings.RIGHTS_EVERYONE_ROLE)
 
         app.logger.info(f'Loading Redis database')
         with app.app_context():

--- a/src/layman/common/prime_db_schema/migrate_test.py
+++ b/src/layman/common/prime_db_schema/migrate_test.py
@@ -1,72 +1,77 @@
-import test.flask_client as client_util
+import logging
+import pytest
 
-from layman import settings, app as app
+from test import process, process_client
+
+from layman import settings, app as app, util
+from layman.layer import LAYER_TYPE
+from layman.map import MAP_TYPE
 from . import model, publications as pub_util, workspaces as workspaces_util
 from .schema_initialization import migrate_users_and_publications, ensure_schema
 from .util import run_query, run_statement
-from layman import util
-from layman.layer import util as layer_util
-from layman.map import util as map_util
+
 
 DB_SCHEMA = settings.LAYMAN_PRIME_SCHEMA
-client = client_util.client
+ensure_layman = process.ensure_layman
+
+logger = logging.getLogger(__name__)
 
 
-def test_recreate_schema(client):
+@pytest.mark.usefixtures('ensure_layman')
+def test_recreate_schema():
     username = 'test_recreate_schema_user1'
-    client_util.publish_layer(username, 'test_recreate_schema_layer1', client)
-    client_util.publish_map(username, 'test_recreate_schema_map1', client)
+    process_client.publish_layer(username, 'test_recreate_schema_layer1')
+    process_client.publish_map(username, 'test_recreate_schema_map1')
 
     with app.app_context():
         run_statement(model.DROP_SCHEMA_SQL)
         ensure_schema(settings.LAYMAN_PRIME_SCHEMA,
-                      app,
-                      settings.PUBLICATION_MODULES)
+                      settings.PUBLICATION_MODULES,
+                      settings.RIGHTS_EVERYONE_ROLE)
 
-    client_util.delete_layer(username, 'test_recreate_schema_layer1', client)
-    client_util.delete_map(username, 'test_recreate_schema_map1', client)
+    process_client.delete_layer(username, 'test_recreate_schema_layer1')
+    process_client.delete_map(username, 'test_recreate_schema_map1')
 
     with app.app_context():
-        pubs = layer_util.get_layer_infos(username)
-        assert len(pubs) == 0
-        pubs = map_util.get_map_infos(username)
+        pubs = pub_util.get_publication_infos(username)
         assert len(pubs) == 0
 
 
-def test_schema(client):
+@pytest.mark.usefixtures('ensure_layman')
+def test_schema():
     username = 'migration_test_user1'
     layername = 'migration_test_layer1'
     mapname = 'migration_test_map1'
-    client_util.publish_layer(username, layername, client)
-    client_util.publish_map(username, mapname, client)
+    process_client.publish_layer(username, layername)
+    process_client.publish_map(username, mapname)
 
     with app.app_context():
         run_statement(model.DROP_SCHEMA_SQL)
         ensure_schema(settings.LAYMAN_PRIME_SCHEMA,
-                      app,
-                      settings.PUBLICATION_MODULES)
+                      settings.PUBLICATION_MODULES,
+                      settings.RIGHTS_EVERYONE_ROLE)
+
         workspaces = run_query(f'select count(*) from {DB_SCHEMA}.workspaces;')
         assert workspaces[0][0] == len(util.get_usernames())
         user_infos = workspaces_util.get_workspace_infos(username)
         assert username in user_infos
         pub_infos = pub_util.get_publication_infos(username)
-        assert layername in pub_infos
-        assert mapname in pub_infos
+        assert (username, LAYER_TYPE, layername) in pub_infos
+        assert (username, MAP_TYPE, mapname) in pub_infos
 
-    client_util.delete_layer(username, layername, client)
-    client_util.delete_map(username, mapname, client)
+    process_client.delete_layer(username, layername)
+    process_client.delete_map(username, mapname)
 
     with app.app_context():
-        pubs = layer_util.get_layer_infos(username)
-        assert len(pubs) == 0
-        pubs = map_util.get_map_infos(username)
+        pubs = pub_util.get_publication_infos(username)
         assert len(pubs) == 0
 
 
-def test_steps(client):
+@pytest.mark.usefixtures('ensure_layman')
+def test_steps():
     username = 'migration_test_user2'
-    client_util.publish_layer(username, 'migration_test_layer2', client)
-    client_util.publish_map(username, 'migration_test_map2', client)
+    process_client.publish_layer(username, 'migration_test_layer2')
+    process_client.publish_map(username, 'migration_test_map2')
 
     with app.app_context():
         run_statement(model.DROP_SCHEMA_SQL)
@@ -87,11 +92,11 @@ def test_steps(client):
         assert exists_workspaces[0][0] == 0
         exists_pubs = run_query(f'select count(*) from {DB_SCHEMA}.publications;')
         assert exists_pubs[0][0] == 0
-        migrate_users_and_publications(settings.PUBLICATION_MODULES)
+        migrate_users_and_publications(settings.PUBLICATION_MODULES, settings.RIGHTS_EVERYONE_ROLE)
         exists_workspaces = run_query(f'select count(*) from {DB_SCHEMA}.workspaces;')
         assert exists_workspaces[0][0] > 0
         exists_pubs = run_query(f'select count(*) from {DB_SCHEMA}.publications;')
         assert exists_pubs[0][0] > 0
 
-    client_util.delete_layer(username, 'migration_test_layer2', client)
-    client_util.delete_map(username, 'migration_test_map2', client)
+    process_client.delete_layer(username, 'migration_test_layer2')
+    process_client.delete_map(username, 'migration_test_map2')

--- a/src/layman/common/prime_db_schema/model.py
+++ b/src/layman/common/prime_db_schema/model.py
@@ -137,7 +137,7 @@ CREATE TABLE {DB_SCHEMA}.publications
     name VARCHAR(256) COLLATE pg_catalog."default" not null,
     title VARCHAR(256) COLLATE pg_catalog."default" not null,
     type VARCHAR(64) COLLATE pg_catalog."default" not null references {DB_SCHEMA}.publication_types (name),
-    uuid VARCHAR(256) COLLATE pg_catalog."default" not null,
+    uuid uuid not null,
     everyone_can_read boolean not null,
     everyone_can_write boolean not null,
     constraint publications_pkey primary key (id),

--- a/src/layman/common/prime_db_schema/publications.py
+++ b/src/layman/common/prime_db_schema/publications.py
@@ -76,8 +76,8 @@ returning id
             info.get("title"),
             info.get("publ_type_name"),
             info.get("uuid"),
-            ROLE_EVERYONE in set(),
-            ROLE_EVERYONE in set(),
+            True,
+            True,
             )
     pub_id = util.run_query(insert_publications_sql, data)[0][0]
 
@@ -97,8 +97,8 @@ def update_publication(workspace_name, info):
     ;'''
 
     data = (info.get("title"),
-            ROLE_EVERYONE in set(),
-            ROLE_EVERYONE in set(),
+            True,
+            True,
             id_workspace,
             info.get("name"),
             info.get("publ_type_name"),

--- a/src/layman/common/prime_db_schema/publications.py
+++ b/src/layman/common/prime_db_schema/publications.py
@@ -1,53 +1,70 @@
+import logging
+import psycopg2.extras
+
 from . import util, workspaces
-from layman import settings, app
+from layman import settings
+
+logger = logging.getLogger(__name__)
 
 DB_SCHEMA = settings.LAYMAN_PRIME_SCHEMA
 ROLE_EVERYONE = settings.RIGHTS_EVERYONE_ROLE
+psycopg2.extras.register_uuid()
 
 
-def get_publication_infos(username=None, pub_type=None):
-    sql = f"""with const as (select %s username, %s pub_type)
-select w.name as username,
+def get_publication_infos(workspace_name=None, pub_type=None):
+    sql = f"""with const as (select %s workspace_name, %s pub_type, %s everyone_role)
+select p.id as id_publication,
+       w.name as workspace_name,
        p.type,
        p.name,
        p.title,
-       p.uuid,
-       p.everyone_can_read,
-       p.everyone_can_write,
-       (select COALESCE(string_agg(w.name, ', '), '')
+       p.uuid::text,
+       (select rtrim(concat(case when u.id is not null then w.name || ',' end,
+                            string_agg(w2.name, ',') || ',',
+                            case when p.everyone_can_read then c.everyone_role || ',' end
+                            ), ',')
         from {DB_SCHEMA}.rights r inner join
-             {DB_SCHEMA}.users u on r.id_user = u.id inner join
-             {DB_SCHEMA}.workspaces w on w.id = u.id_workspace
+             {DB_SCHEMA}.users u2 on r.id_user = u2.id inner join
+             {DB_SCHEMA}.workspaces w2 on w2.id = u2.id_workspace
         where r.id_publication = p.id
           and r.type = 'read') can_read_users,
-       (select COALESCE(string_agg(w.name, ', '), '')
+       (select rtrim(concat(case when u.id is not null then w.name || ',' end,
+                            string_agg(w2.name, ',') || ',',
+                            case when p.everyone_can_read then c.everyone_role || ',' end
+                            ), ',')
         from {DB_SCHEMA}.rights r inner join
-             {DB_SCHEMA}.users u on r.id_user = u.id inner join
-             {DB_SCHEMA}.workspaces w on w.id = u.id_workspace
+             {DB_SCHEMA}.users u2 on r.id_user = u2.id inner join
+             {DB_SCHEMA}.workspaces w2 on w2.id = u2.id_workspace
         where r.id_publication = p.id
           and r.type = 'write') can_write_users
 from const c inner join
-     {DB_SCHEMA}.workspaces w on (   w.name = c.username
-                                  or c.username is null) inner join
+     {DB_SCHEMA}.workspaces w on (   w.name = c.workspace_name
+                                  or c.workspace_name is null) inner join
      {DB_SCHEMA}.publications p on p.id_workspace = w.id
                            and (   p.type = c.pub_type
-                                or c.pub_type is null)
+                                or c.pub_type is null) left join
+     {DB_SCHEMA}.users u on u.id_workspace = w.id
 ;"""
-    values = util.run_query(sql, (username, pub_type,))
-    infos = {layername: {'name': layername,
-                         'title': title,
-                         'uuid': uuid,
-                         'type': type,
-                         # 'can_read': set(),  # To be combination of everyone_can_read and can_read_users
-                         # 'can_write': set(),  # To be combination of everyone_can_write and can_write_users
-                         }
-             for username, type, layername, title, uuid, everyone_can_read, everyone_can_write, can_read_users, can_write_users
+    values = util.run_query(sql, (workspace_name,
+                                  pub_type,
+                                  ROLE_EVERYONE,
+                                  ))
+    infos = {(workspace_name,
+              type,
+              publication_name,): {'id': id_publication,
+                                   'name': publication_name,
+                                   'title': title,
+                                   'uuid': uuid,
+                                   'type': type,
+                                   }
+             for id_publication, workspace_name, type, publication_name, title, uuid, can_read_users, can_write_users
              in values}
     return infos
 
 
-def insert_publication(username, info):
-    id_workspace = workspaces.ensure_workspace(username)
+def insert_publication(workspace_name, info):
+    id_workspace = workspaces.ensure_workspace(workspace_name)
+
     insert_publications_sql = f'''insert into {DB_SCHEMA}.publications as p
         (id_workspace, name, title, type, uuid, everyone_can_read, everyone_can_write) values
         (%s, %s, %s, %s, %s, %s, %s)
@@ -59,38 +76,39 @@ returning id
             info.get("title"),
             info.get("publ_type_name"),
             info.get("uuid"),
-            ROLE_EVERYONE in info.get("can_read"),
-            ROLE_EVERYONE in info.get("can_write"),
+            ROLE_EVERYONE in set(),
+            ROLE_EVERYONE in set(),
             )
-    pub_id = util.run_query(insert_publications_sql, data)
+    pub_id = util.run_query(insert_publications_sql, data)[0][0]
+
     return pub_id
 
 
-def update_publication(username, info):
-    id_workspace = workspaces.get_workspace_infos(username)[username]["id"]
-    insert_publications_sql = f'''update {DB_SCHEMA}.publications set
-    title = coalesce(%s, title),
-    everyone_can_read = coalesce(%s, everyone_can_read),
-    everyone_can_write = coalesce(%s, everyone_can_write)
-where id_workspace = %s
-  and name = %s
-  and type = %s
-returning id
-;'''
+def update_publication(workspace_name, info):
+    id_workspace = workspaces.get_workspace_infos(workspace_name)[workspace_name]["id"]
+    update_publications_sql = f'''update {DB_SCHEMA}.publications set
+        title = coalesce(%s, title),
+        everyone_can_read = coalesce(%s, everyone_can_read),
+        everyone_can_write = coalesce(%s, everyone_can_write)
+    where id_workspace = %s
+      and name = %s
+      and type = %s
+    returning id
+    ;'''
 
     data = (info.get("title"),
-            ROLE_EVERYONE in (info.get("can_read") or set()),
-            ROLE_EVERYONE in (info.get("can_write") or set()),
+            ROLE_EVERYONE in set(),
+            ROLE_EVERYONE in set(),
             id_workspace,
             info.get("name"),
             info.get("publ_type_name"),
             )
-    pub_id = util.run_query(insert_publications_sql, data)
+    pub_id = util.run_query(update_publications_sql, data)[0][0]
     return pub_id
 
 
-def delete_publication(username, name, type):
-    workspace_info = workspaces.get_workspace_infos(username).get(username)
+def delete_publication(workspace_name, type, name):
+    workspace_info = workspaces.get_workspace_infos(workspace_name).get(workspace_name)
     if workspace_info:
         id_workspace = workspace_info["id"]
         sql = f"""delete from {DB_SCHEMA}.publications p where p.id_workspace = %s and p.name = %s and p.type = %s;"""
@@ -98,4 +116,4 @@ def delete_publication(username, name, type):
                                  name,
                                  type,))
     else:
-        app.logger.warning(f'Deleting publication for NON existing workspace. workspace_name={username}, pub_name={name}, type={type}')
+        logger.warning(f'Deleting publication for NON existing workspace. workspace_name={workspace_name}, pub_name={name}, type={type}')

--- a/src/layman/common/prime_db_schema/publications_test.py
+++ b/src/layman/common/prime_db_schema/publications_test.py
@@ -22,7 +22,6 @@ userinfo = {"iss_id": 'mock_test',
             }
 
 
-@pytest.mark.usefixtures('ensure_layman')
 def test_publication_basic():
     def publications_by_type(prefix,
                              publication_type,

--- a/src/layman/common/prime_db_schema/schema_initialization.py
+++ b/src/layman/common/prime_db_schema/schema_initialization.py
@@ -1,48 +1,54 @@
+import logging
+
 from layman.http import LaymanError
 from layman.authn.filesystem import get_authn_info
 from layman.common.prime_db_schema import workspaces, users, publications
 from layman.common.util import merge_infos
-from layman.util import get_modules_from_names, call_modules_fn, get_usernames as global_get_usernames
+from layman.util import get_modules_from_names, call_modules_fn, get_usernames as global_get_workspaces
 from . import util as db_util, model
 
+logger = logging.getLogger(__name__)
 
-def migrate_users_and_publications(modules):
-    usernames = global_get_usernames(use_cache=False)
 
-    for username in usernames:
-        userinfo = get_authn_info(username)
-        id_workspace = workspaces.ensure_workspace(username)
-        if userinfo != {}:
+def migrate_users_and_publications(modules, role_everyone):
+    workspace_names = global_get_workspaces(use_cache=False)
+
+    for workspace_name in workspace_names:
+        userinfo = get_authn_info(workspace_name)
+        id_workspace = workspaces.ensure_workspace(workspace_name)
+        if userinfo:
+            # It is personal workspace
             users.ensure_user(id_workspace, userinfo)
         for publ_module in get_modules_from_names(modules):
             for type_def in publ_module.PUBLICATION_TYPES.values():
                 publ_type_name = type_def['type']
                 sources = get_modules_from_names(type_def['internal_sources'])
-                results = call_modules_fn(sources, 'get_publication_infos', [username, publ_type_name])
+                results = call_modules_fn(sources, 'get_publication_infos', [workspace_name, publ_type_name])
                 pubs = merge_infos(results)
                 for name, info in pubs.items():
                     pub_info = {"name": name,
                                 "title": info.get("title"),
                                 "publ_type_name": publ_type_name,
-                                "uuid": info.get("uuid"),
+                                "uuid": info["uuid"],
                                 "can_read": set(),
                                 "can_write": set(),
                                 }
-                    publications.insert_publication(username, pub_info)
+                    publications.insert_publication(workspace_name, pub_info)
 
 
-def ensure_schema(db_schema, app, modules):
+def ensure_schema(db_schema,
+                  modules,
+                  role_everyone):
     exists_schema = db_util.run_query(model.EXISTS_SCHEMA_SQL)
     if exists_schema[0][0] == 0:
-        app.logger.info(f"Going to create Layman DB schema, schema_name={db_schema}")
         db_util.run_statement(model.CREATE_SCHEMA_SQL)
         db_util.run_statement(model.setup_codelists_data())
-        migrate_users_and_publications(modules)
+        migrate_users_and_publications(modules, role_everyone)
     else:
-        app.logger.info(f"Layman DB schema already exists, schema_name={db_schema}")
+        logger.info(f"Layman DB schema already exists, schema_name={db_schema}")
 
 
 def check_schema_name(db_schema):
-    usernames = global_get_usernames(use_cache=False, skip_modules=('layman.map.prime_db_schema', 'layman.layer.prime_db_schema', ))
+    usernames = global_get_workspaces(use_cache=False, skip_modules=('layman.map.prime_db_schema', 'layman.layer.prime_db_schema',))
     if db_schema in usernames:
         raise LaymanError(42, {'username': db_schema})

--- a/src/layman/common/prime_db_schema/users_test.py
+++ b/src/layman/common/prime_db_schema/users_test.py
@@ -7,6 +7,7 @@ from test import process
 DB_SCHEMA = settings.LAYMAN_PRIME_SCHEMA
 ensure_layman = process.ensure_layman
 
+
 @pytest.mark.usefixtures('ensure_layman')
 def test_get_user_infos():
     with app.app_context():

--- a/src/layman/common/prime_db_schema/users_test.py
+++ b/src/layman/common/prime_db_schema/users_test.py
@@ -8,7 +8,6 @@ DB_SCHEMA = settings.LAYMAN_PRIME_SCHEMA
 ensure_layman = process.ensure_layman
 
 
-@pytest.mark.usefixtures('ensure_layman')
 def test_get_user_infos():
     with app.app_context():
         user_util.get_user_infos()
@@ -16,7 +15,6 @@ def test_get_user_infos():
         user_util.get_user_infos('asůldghwíeghsdlkfj')
 
 
-@pytest.mark.usefixtures('ensure_layman')
 def test_ensure_user():
     username = 'test_ensure_user'
     userinfo = {"iss_id": 'mock_test',

--- a/src/layman/common/prime_db_schema/users_test.py
+++ b/src/layman/common/prime_db_schema/users_test.py
@@ -1,19 +1,22 @@
-from test.flask_client import client
+import pytest
 
 from layman import settings, app as app
 from . import users as user_util, workspaces as workspace_util
+from test import process
 
 DB_SCHEMA = settings.LAYMAN_PRIME_SCHEMA
+ensure_layman = process.ensure_layman
 
-
-def test_get_user_infos(client):
+@pytest.mark.usefixtures('ensure_layman')
+def test_get_user_infos():
     with app.app_context():
         user_util.get_user_infos()
         user_util.get_user_infos('test2')
         user_util.get_user_infos('asůldghwíeghsdlkfj')
 
 
-def test_ensure_user(client):
+@pytest.mark.usefixtures('ensure_layman')
+def test_ensure_user():
     username = 'test_ensure_user'
     userinfo = {"iss_id": 'mock_test',
                 "sub": '1',

--- a/src/layman/common/prime_db_schema/util.py
+++ b/src/layman/common/prime_db_schema/util.py
@@ -33,8 +33,8 @@ def run_query(query, data=None, conn_cur=None):
         cur.execute(query, data)
         rows = cur.fetchall()
         conn.commit()
-    except BaseException:
-        app.logger.error(f"run_query, query={query}, data={data}")
+    except BaseException as exc:
+        app.logger.error(f"run_query, query={query}, data={data}, exc={exc}")
         raise LaymanError(7)
 
     return rows
@@ -47,18 +47,6 @@ def run_statement(query, data=None, conn_cur=None):
     try:
         cur.execute(query, data)
         conn.commit()
-    except BaseException:
-        app.logger.error(f"run_query, query={query}, data={data}")
-        raise LaymanError(7)
-
-
-def run_statement_many(query, data, conn_cur=None):
-    if conn_cur is None:
-        conn_cur = get_connection_cursor()
-    conn, cur = conn_cur
-    try:
-        cur.executemany(query, data)
-        conn.commit()
-    except BaseException:
-        app.logger.error(f"run_query, query={query}, data={data}")
+    except BaseException as exc:
+        app.logger.error(f"run_query, query={query}, data={data}, exc={exc}")
         raise LaymanError(7)

--- a/src/layman/common/prime_db_schema/workspaces_test.py
+++ b/src/layman/common/prime_db_schema/workspaces_test.py
@@ -1,17 +1,22 @@
-from test.flask_client import client
+import pytest
 
 from layman import app as app
 from . import users as user_util, workspaces as workspace_util, ensure_whole_user
+from test import process
+
+ensure_layman = process.ensure_layman
 
 
-def test_get_workspace_infos(client):
+@pytest.mark.usefixtures('ensure_layman')
+def test_get_workspace_infos():
     with app.app_context():
         workspace_util.get_workspace_infos()
         workspace_util.get_workspace_infos('test2')
         workspace_util.get_workspace_infos('asůldghwíeghsdlkfj')
 
 
-def test_ensure_workspace(client):
+@pytest.mark.usefixtures('ensure_layman')
+def test_ensure_workspace():
     username = 'test_ensure_workspace_user'
 
     with app.app_context():

--- a/src/layman/common/prime_db_schema/workspaces_test.py
+++ b/src/layman/common/prime_db_schema/workspaces_test.py
@@ -2,12 +2,8 @@ import pytest
 
 from layman import app as app
 from . import users as user_util, workspaces as workspace_util, ensure_whole_user
-from test import process
-
-ensure_layman = process.ensure_layman
 
 
-@pytest.mark.usefixtures('ensure_layman')
 def test_get_workspace_infos():
     with app.app_context():
         workspace_util.get_workspace_infos()
@@ -15,7 +11,6 @@ def test_get_workspace_infos():
         workspace_util.get_workspace_infos('asůldghwíeghsdlkfj')
 
 
-@pytest.mark.usefixtures('ensure_layman')
 def test_ensure_workspace():
     username = 'test_ensure_workspace_user'
 

--- a/src/layman/layer/prime_db_schema/table.py
+++ b/src/layman/layer/prime_db_schema/table.py
@@ -6,25 +6,23 @@ PATCH_MODE = patch_mode.DELETE_IF_DEPENDANT
 
 
 def get_layer_infos(username):
-    return pubs_util.get_publication_infos(username, LAYER_TYPE)
+    result = {layername: layer_info for (username_value, type, layername), layer_info in pubs_util.get_publication_infos(username, LAYER_TYPE).items()}
+    return result
 
 
 def get_publication_uuid(username, publication_type, publication_name):
     infos = pubs_util.get_publication_infos(username, publication_type)
-    return infos.get(publication_name).get("uuid")
+    return infos.get((username, publication_type, publication_name), dict()).get("uuid")
 
 
 def get_layer_info(username, layername):
     layers = pubs_util.get_publication_infos(username, LAYER_TYPE)
-    if layername in layers:
-        info = layers[layername]
-    else:
-        info = {}
+    info = layers.get((username, LAYER_TYPE, layername), dict())
     return info
 
 
-def delete_layer(username, layername):
-    pubs_util.delete_publication(username, layername, LAYER_TYPE)
+def delete_layer(username, layer_name):
+    return pubs_util.delete_publication(username, LAYER_TYPE, layer_name)
 
 
 def patch_layer(username,
@@ -61,7 +59,12 @@ def post_layer(username,
     pubs_util.insert_publication(username, db_info)
 
 
-get_publication_infos = pubs_util.get_publication_infos
+def get_publication_infos(username, publication_type):
+    if publication_type != '.'.join(__name__.split('.')[:-2]):
+        raise Exception(f'Unknown pyblication type {publication_type}')
+
+    infos = get_layer_infos(username)
+    return infos
 
 
 def get_metadata_comparison(username, publication_name):

--- a/src/layman/layer/rest_layers_test.py
+++ b/src/layman/layer/rest_layers_test.py
@@ -10,7 +10,7 @@ from .geoserver import wfs, wms, sld
 from .micka import soap
 from . import util, LAYER_TYPE
 from layman.util import url_for
-from test import flask_client as client_util
+from test import flask_client as client_util, util as test_util
 
 client = client_util.client
 
@@ -96,15 +96,14 @@ def test_get_layer_infos(client):
 
         for module in modules:
             layer_infos = module["method_infos"](username)
-            assert layer_infos == module["result_infos"], \
-                (module["name"], module["method_infos"].__module__, layer_infos)
-            publication_infos = module["method_publications"](username, "layman.layer")
-            assert publication_infos == module["result_infos"], \
-                (module["name"], module["method_publications"].__module__, publication_infos)
+            test_util.assert_same_infos(layer_infos, module["result_infos"], module)
+
+            publication_infos = module["method_publications"](username, LAYER_TYPE)
+            test_util.assert_same_infos(publication_infos, module["result_infos"], module)
 
         # util
         layer_infos = util.get_layer_infos(username)
-        assert layer_infos == result_infos_all, layer_infos
+        test_util.assert_same_infos(layer_infos, result_infos_all)
 
     client_util.delete_layer(username, layername, client)
 

--- a/src/layman/layer/rest_test.py
+++ b/src/layman/layer/rest_test.py
@@ -32,8 +32,10 @@ from .micka import csw
 from layman.common.micka import util as micka_common_util
 from layman.common.metadata import prop_equals_strict, PROPERTIES
 from test.data import wfs as data_wfs
+from test import flask_client
 
 logger = logging.getLogger(__name__)
+
 
 TODAY_DATE = date.today().strftime('%Y-%m-%d')
 

--- a/src/layman/map/prime_db_schema/table.py
+++ b/src/layman/map/prime_db_schema/table.py
@@ -3,20 +3,18 @@ from .. import MAP_TYPE
 
 
 def get_map_infos(username):
-    return pubs_util.get_publication_infos(username, MAP_TYPE)
+    result = {mapname: map_info for (username_value, type, mapname), map_info in pubs_util.get_publication_infos(username, MAP_TYPE).items()}
+    return result
 
 
 def get_publication_uuid(username, publication_type, publication_name):
     infos = pubs_util.get_publication_infos(username, publication_type)
-    return infos.get(publication_name).get("uuid")
+    return infos.get((username, publication_type, publication_name), dict()).get("uuid")
 
 
 def get_map_info(username, mapname):
     maps = pubs_util.get_publication_infos(username, MAP_TYPE)
-    if mapname in maps:
-        info = maps[mapname]
-    else:
-        info = {}
+    info = maps.get((username, MAP_TYPE, mapname), dict())
     return info
 
 
@@ -55,11 +53,16 @@ def post_map(username,
     pubs_util.insert_publication(username, db_info)
 
 
-get_publication_infos = pubs_util.get_publication_infos
+def get_publication_infos(username, publication_type):
+    if publication_type != '.'.join(__name__.split('.')[:-2]):
+        raise Exception(f'Unknown pyblication type {publication_type}')
+
+    infos = get_map_infos(username)
+    return infos
 
 
-def delete_map(username, mapname):
-    pubs_util.delete_publication(username, mapname, MAP_TYPE)
+def delete_map(username, map_name):
+    return pubs_util.delete_publication(username, MAP_TYPE, map_name)
 
 
 def get_metadata_comparison(username, publication_name):

--- a/src/layman/map/rest_maps_test.py
+++ b/src/layman/map/rest_maps_test.py
@@ -8,7 +8,7 @@ from .micka import soap
 from .prime_db_schema import table as prime_table
 from . import util, MAP_TYPE
 from layman.util import url_for
-from test import flask_client as client_util
+from test import flask_client as client_util, util as test_util
 
 client = client_util.client
 
@@ -65,14 +65,13 @@ def test_get_map_infos(client):
 
         for module in modules:
             map_infos = module["method_infos"](username)
-            assert map_infos == module["result_infos"],\
-                (module["name"], module["method_infos"].__module__, map_infos)
-            publication_infos = module["method_publications"](username, "layman.map")
-            assert publication_infos == module["result_infos"],\
-                (module["name"], module["method_publications"].__module__, publication_infos)
+            test_util.assert_same_infos(map_infos, module["result_infos"], module)
+
+            publication_infos = module["method_publications"](username, MAP_TYPE)
+            test_util.assert_same_infos(publication_infos, module["result_infos"], module)
 
         map_infos = util.get_map_infos(username)
-        assert map_infos == result_infos_all, map_infos
+        test_util.assert_same_infos(map_infos, result_infos_all)
 
     client_util.delete_map(username, mapname, client)
 

--- a/src/layman/uuid.py
+++ b/src/layman/uuid.py
@@ -162,7 +162,7 @@ def check_redis_consistency(expected_publ_num_by_type=None):
     redis = settings.LAYMAN_REDIS
     user_publ_keys = redis.keys(':'.join(USER_TYPE_NAMES_KEY.split(':')[:2]) + ':*')
     uuid_keys = redis.keys(':'.join(UUID_METADATA_KEY.split(':')[:2]) + ':*')
-    assert num_total_publs == len(uuid_keys), f"total_publs: {total_publs}"
+    assert num_total_publs == len(uuid_keys), f"total_publs={total_publs}, uuid_keys={uuid_keys}"
 
     total_publs_by_type = defaultdict(list)
     for publ in total_publs:

--- a/test/flask_client.py
+++ b/test/flask_client.py
@@ -12,7 +12,11 @@ from layman.util import url_for
 from test.util import wait_for_url
 
 
-def publish_layer(username, layername, client, title=None):
+def publish_layer(username,
+                  layername,
+                  client,
+                  title=None,
+                  ):
     title = title or layername
     with app.app_context():
         rest_path = url_for('rest_layers.post', username=username)
@@ -89,7 +93,12 @@ def delete_map(username, mapname, client, headers=None):
     assert r.status_code == 200, (r.status_code, r.get_json())
 
 
-def publish_map(username, mapname, client, maptitle=None, headers=None):
+def publish_map(username,
+                mapname,
+                client,
+                maptitle=None,
+                headers=None,
+                ):
     maptitle = maptitle or mapname
     headers = headers or {}
     with app.app_context():

--- a/test/process.py
+++ b/test/process.py
@@ -2,12 +2,15 @@ import pytest
 from multiprocessing import Process
 import subprocess
 import os
+import logging
 
 from src.layman import settings
 
 from test.mock.liferay import run
 from test import util
 
+
+logger = logging.getLogger(__name__)
 
 SUBPROCESSES = set()
 LIFERAY_PORT = 8020
@@ -68,6 +71,15 @@ def clear():
     while len(SUBPROCESSES) > 0:
         proc = next(iter(SUBPROCESSES))
         stop_process(proc)
+
+
+@pytest.fixture(scope="module")
+def ensure_layman():
+    print(f'\nEnsure layman is starting')
+    processes = start_layman()
+    yield
+    stop_process(processes)
+    print(f'\nEnsure layman is ending')
 
 
 def start_layman(env_vars=None):

--- a/test/process_client.py
+++ b/test/process_client.py
@@ -1,13 +1,19 @@
 import time
 import requests
 import os
+import logging
 
-from layman import settings
+from layman import settings, app
+from layman.util import url_for
+from layman.layer.geoserver import wfs, wms
+
+logger = logging.getLogger(__name__)
 
 ISS_URL_HEADER = 'AuthorizationIssUrl'
 TOKEN_HEADER = 'Authorization'
 
 layer_keys_to_check = ['db_table', 'wms', 'wfs', 'thumbnail', 'file', 'metadata']
+map_keys_to_check = ['thumbnail', 'file', 'metadata']
 
 
 def wait_for_rest(url, max_attempts, sleeping_time, keys_to_check):
@@ -27,56 +33,147 @@ def wait_for_rest(url, max_attempts, sleeping_time, keys_to_check):
 def publish_layer(username,
                   layername,
                   file_paths=None,
-                  headers=None):
+                  headers=None,
+                  title=None,
+                  ):
+    title = title or layername
     headers = headers or {}
     file_paths = file_paths or ['tmp/naturalearth/110m/cultural/ne_110m_admin_0_countries.geojson']
-    rest_url = f"http://{settings.LAYMAN_SERVER_NAME}/rest"
 
-    r_url = f"{rest_url}/{username}/layers"
+    with app.app_context():
+        r_url = url_for('rest_layers.post', username=username)
+
     for fp in file_paths:
         assert os.path.isfile(fp)
     files = []
     try:
+        files = [('file', (os.path.basename(fp), open(fp, 'rb'))) for fp in file_paths]
+        data = {'name': layername,
+                'title': title,
+                }
         r = requests.post(r_url,
-                          files=[('file', (os.path.basename(fp), open(fp, 'rb'))) for fp in file_paths],
-                          data={'name': layername, },
+                          files=files,
+                          data=data,
                           headers=headers)
         assert r.status_code == 200, r.text
     finally:
         for fp in files:
-            fp[0].close()
+            fp[1][1].close()
 
-    wait_for_rest(f"{rest_url}/{username}/layers/{layername}", 20, 0.5, layer_keys_to_check)
+    with app.app_context():
+        url = url_for('rest_layer.get', username=username, layername=layername)
+    wait_for_rest(url, 20, 0.5, layer_keys_to_check)
     return layername
 
 
-def patch_layer(username, layername, file_paths, headers=None):
+def patch_layer(username,
+                layername,
+                file_paths=None,
+                headers=None,
+                ):
     headers = headers or {}
-    rest_url = f"http://{settings.LAYMAN_SERVER_NAME}/rest"
+    file_paths = file_paths or []
 
-    r_url = f"{rest_url}/{username}/layers/{layername}"
+    with app.app_context():
+        r_url = url_for('rest_layer.patch', username=username, layername=layername)
+
     for fp in file_paths:
         assert os.path.isfile(fp)
     files = []
     try:
-        r = requests.patch(r_url, files=[
-            ('file', (os.path.basename(fp), open(fp, 'rb')))
-            for fp in file_paths
-        ], headers=headers)
+        files = [('file', (os.path.basename(fp), open(fp, 'rb'))) for fp in file_paths]
+        data = dict()
+
+        r = requests.patch(r_url,
+                           files=files,
+                           headers=headers,
+                           data=data)
         assert r.status_code == 200, r.text
     finally:
         for fp in files:
-            fp[0].close()
+            fp[1][1].close()
 
-    wait_for_rest(f"{rest_url}/{username}/layers/{layername}", 20, 0.5, layer_keys_to_check)
+    with app.app_context():
+        url = url_for('rest_layer.get', username=username, layername=layername)
+    wait_for_rest(url, 20, 0.5, layer_keys_to_check)
+    wfs.clear_cache(username)
+    wms.clear_cache(username)
     return layername
+
+
+def patch_map(username,
+              mapname,
+              headers=None,
+              ):
+    headers = headers or {}
+
+    with app.app_context():
+        r_url = url_for('rest_map.patch', username=username, mapname=mapname)
+
+    data = dict()
+
+    r = requests.patch(r_url,
+                       headers=headers,
+                       data=data)
+    assert r.status_code == 200, r.text
+
+    with app.app_context():
+        url = url_for('rest_map.get', username=username, mapname=mapname)
+    wait_for_rest(url, 20, 0.5, map_keys_to_check)
+    wfs.clear_cache(username)
+    wms.clear_cache(username)
+    return mapname
 
 
 def delete_layer(username, layername, headers=None):
     headers = headers or {}
-    rest_url = f"http://{settings.LAYMAN_SERVER_NAME}/rest"
 
-    r_url = f"{rest_url}/{username}/layers/{layername}"
+    with app.app_context():
+        r_url = url_for('rest_layer.delete_layer', username=username, layername=layername)
+    r = requests.delete(r_url, headers=headers)
+    assert r.status_code == 200, r.text
+    wfs.clear_cache(username)
+    wms.clear_cache(username)
+
+
+def publish_map(username,
+                mapname,
+                file_paths=None,
+                headers=None,
+                ):
+    headers = headers or {}
+    file_paths = file_paths or ['sample/layman.map/full.json', ]
+
+    with app.app_context():
+        r_url = url_for('rest_maps.post', username=username)
+
+    for fp in file_paths:
+        assert os.path.isfile(fp)
+    files = []
+    try:
+        files = [('file', (os.path.basename(fp), open(fp, 'rb'))) for fp in file_paths]
+        data = {'name': mapname, }
+        r = requests.post(r_url,
+                          files=files,
+                          data=data,
+                          headers=headers)
+        assert r.status_code == 200, r.text
+    finally:
+        for fp in files:
+            fp[1][1].close()
+
+    with app.app_context():
+        url = url_for('rest_map.get', username=username, mapname=mapname)
+    wait_for_rest(url, 20, 0.5, map_keys_to_check)
+    return mapname
+
+
+def delete_map(username, mapname, headers=None):
+    headers = headers or {}
+
+    with app.app_context():
+        r_url = url_for('rest_map.delete_map', username=username, mapname=mapname)
+
     r = requests.delete(r_url, headers=headers)
     assert r.status_code == 200, r.text
 

--- a/test/util.py
+++ b/test/util.py
@@ -18,3 +18,12 @@ def wait_for_url(url, max_attempts, sleeping_time):
                 raise e
             attempt += 1
         time.sleep(sleeping_time)
+
+
+def assert_same_infos(info_to_test,
+                      expected_info,
+                      more_info=None):
+    for publication_name in info_to_test:
+        if info_to_test[publication_name].get('id'):
+            del info_to_test[publication_name]['id']
+    assert info_to_test == expected_info, (info_to_test, more_info)


### PR DESCRIPTION
Improvements in prime_db_publications:
- get_publication_infos return dictionary with tuple (workspace, pub_type, pub_name) as a key
- uuid is type uuid
- use workspace instead of username for variable names
Small improvements in prime_db_schema migration
Use Layman Test Client v1.3.0 